### PR TITLE
Add parentheses to function calls

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule PhoenixAlexa.Mixfile do
      version: @version,
      elixir: "~> 1.2",
      description: "Alexa library for Phoenix",
-     deps: deps,
-     package: package,
+     deps: deps(),
+     package: package(),
      consolidate_protocols: Mix.env != :test]
   end
 


### PR DESCRIPTION
As of [Elixir 1.4.0](https://github.com/elixir-lang/elixir/releases/tag/v1.4.0), the compiler issues a warning function calls are made without parentheses. 

>warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /my_project/deps/phoenix_alexa/mix.exs:11
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /my_project/deps/phoenix_alexa/mix.exs:12

Adding parentheses to `deps()` and `package()` in the Mixfile addresses the warning.